### PR TITLE
make parsing of auhtorized engine header more robust

### DIFF
--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -97,7 +97,7 @@ ngModule.config([
     var window = $windowProvider.$get();
     var uri = window.location.href;
 
-    var match = uri.match(/\/app\/([\w-]+)\/([\w-]+)\//);
+    var match = uri.match(/\/(?:app)(?!.*app)\/([\w-]+)\/([\w-]+)\//);
     if (match) {
       $httpProvider.defaults.headers.get = {'X-Authorized-Engine': match[2]};
     } else {


### PR DESCRIPTION
[![](https://badgen.net/badge/JIRA//0052CC)](https://app.camunda.com/jira/browse/)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Due to our company's operation guidelines we need to deploy camunda to a predefined context path that looks like this: `example.com/some/path/app/`. Since camunda is adding another `/app/` itself, the wrong engine name is parsed. As a consequence we get a wrong `X-Authorized-Engine` header and cannot use the features that require a license key.

In our example we have `example.com/some/path/app/app/welcome/default/#!/login` as `window.location.href`. The parser would take the second path segment after the **first** occurence of `app` which in our case would be `welcome`. But what we need is the engine name `default`. I changed the regular expression such that the parsing picks the **last** occurence of `app` using negative lookahead.